### PR TITLE
Making FncValues IndexMode public

### DIFF
--- a/src/main/java/net/alenzen/a2l/FncValues.java
+++ b/src/main/java/net/alenzen/a2l/FncValues.java
@@ -11,7 +11,7 @@ public class FncValues implements IA2LWriteable {
 	private IndexMode indexMode;
 	private AddrType addressType;
 
-	enum IndexMode {
+	public enum IndexMode {
 		ALTERNATE_CURVES, ALTERNATE_WITH_X, ALTERNATE_WITH_Y, COLUMN_DIR, ROW_DIR
 	}
 


### PR DESCRIPTION
Hello Andreas,

While using your library, I was trying to create a new RecordLayout, but I couldn't use the `setIndexMode` public method to initialize a function value, because the IndexMode enum wasn't public.