### PR TITLE
Extending A2lSerializer with ToString method to required classes

### DIFF
--- a/src/main/java/net/alenzen/a2l/A2LSerializer.java
+++ b/src/main/java/net/alenzen/a2l/A2LSerializer.java
@@ -1,0 +1,20 @@
+package net.alenzen.a2l;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+public abstract class A2LSerializer {
+
+    @Override
+    public String toString() {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
+        }
+        catch (JsonProcessingException e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
+}

--- a/src/main/java/net/alenzen/a2l/A2ml.java
+++ b/src/main/java/net/alenzen/a2l/A2ml.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class A2ml implements IA2LWriteable {
+public class A2ml extends A2LSerializer implements IA2LWriteable {
 	private String content;
 
 	public String getContent() {

--- a/src/main/java/net/alenzen/a2l/Annotation.java
+++ b/src/main/java/net/alenzen/a2l/Annotation.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class Annotation implements IA2LWriteable {
+public class Annotation extends A2LSerializer implements IA2LWriteable {
 	private String label;
 	private String origin;
 	private AnnotationText text = new AnnotationText();

--- a/src/main/java/net/alenzen/a2l/Asap2File.java
+++ b/src/main/java/net/alenzen/a2l/Asap2File.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchemaGenerator;
 
-public class Asap2File {
+public class Asap2File extends A2LSerializer {
 	private A2mlVersion a2mlVersion;
 	private Asap2Version asap2Version;
 	private Project project;

--- a/src/main/java/net/alenzen/a2l/AxisDescr.java
+++ b/src/main/java/net/alenzen/a2l/AxisDescr.java
@@ -8,7 +8,7 @@ import net.alenzen.a2l.enums.ByteOrder;
 import net.alenzen.a2l.enums.Deposit;
 import net.alenzen.a2l.enums.Monotony;
 
-public class AxisDescr implements IA2LWriteable {
+public class AxisDescr extends A2LSerializer implements IA2LWriteable {
 	private Attribute attribute;
 	private String inputQuantity;
 	private String conversion;

--- a/src/main/java/net/alenzen/a2l/AxisPts.java
+++ b/src/main/java/net/alenzen/a2l/AxisPts.java
@@ -10,7 +10,7 @@ import net.alenzen.a2l.enums.CalibrationAccess;
 import net.alenzen.a2l.enums.Deposit;
 import net.alenzen.a2l.enums.Monotony;
 
-public class AxisPts implements IA2LWriteable {
+public class AxisPts extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private String longIdentifier;
 	private long address;

--- a/src/main/java/net/alenzen/a2l/AxisPtsXYZ45.java
+++ b/src/main/java/net/alenzen/a2l/AxisPtsXYZ45.java
@@ -6,7 +6,7 @@ import net.alenzen.a2l.enums.AddrType;
 import net.alenzen.a2l.enums.DataType;
 import net.alenzen.a2l.enums.IndexOrder;
 
-public class AxisPtsXYZ45 implements IA2LDimensionWriteable {
+public class AxisPtsXYZ45 extends A2LSerializer implements IA2LDimensionWriteable {
 	private long position;
 	private DataType datatype;
 	private IndexOrder indexorder;

--- a/src/main/java/net/alenzen/a2l/AxisRescaleXYZ45.java
+++ b/src/main/java/net/alenzen/a2l/AxisRescaleXYZ45.java
@@ -6,7 +6,7 @@ import net.alenzen.a2l.enums.AddrType;
 import net.alenzen.a2l.enums.DataType;
 import net.alenzen.a2l.enums.IndexOrder;
 
-public class AxisRescaleXYZ45 implements IA2LDimensionWriteable {
+public class AxisRescaleXYZ45 extends A2LSerializer implements IA2LDimensionWriteable {
 	private long position;
 	private DataType datatype;
 	private long maxNumberOfRescalePairs;

--- a/src/main/java/net/alenzen/a2l/BitOperation.java
+++ b/src/main/java/net/alenzen/a2l/BitOperation.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class BitOperation implements IA2LWriteable {
+public class BitOperation extends A2LSerializer implements IA2LWriteable {
 	// optional parameters
 	private Long leftShift;
 	private Long rightShift;

--- a/src/main/java/net/alenzen/a2l/Blob.java
+++ b/src/main/java/net/alenzen/a2l/Blob.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class Blob implements IA2LWriteable {
+public class Blob extends A2LSerializer implements IA2LWriteable {
 	private String content;
 
 	public String getContent() {

--- a/src/main/java/net/alenzen/a2l/CalibrationHandle.java
+++ b/src/main/java/net/alenzen/a2l/CalibrationHandle.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class CalibrationHandle implements IA2LWriteable {
+public class CalibrationHandle extends A2LSerializer implements IA2LWriteable {
 	private List<Long> handles;
 
 	// optional parameters

--- a/src/main/java/net/alenzen/a2l/CalibrationMethod.java
+++ b/src/main/java/net/alenzen/a2l/CalibrationMethod.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class CalibrationMethod implements IA2LWriteable {
+public class CalibrationMethod extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private long version;
 

--- a/src/main/java/net/alenzen/a2l/Characteristic.java
+++ b/src/main/java/net/alenzen/a2l/Characteristic.java
@@ -8,7 +8,7 @@ import net.alenzen.a2l.enums.ByteOrder;
 import net.alenzen.a2l.enums.CalibrationAccess;
 import net.alenzen.a2l.enums.CharacteristicType;
 
-public class Characteristic implements IA2LWriteable {
+public class Characteristic extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private String longIdentifier;
 	private CharacteristicType type;

--- a/src/main/java/net/alenzen/a2l/Coeffs.java
+++ b/src/main/java/net/alenzen/a2l/Coeffs.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class Coeffs implements IA2LWriteable {
+public class Coeffs extends A2LSerializer implements IA2LWriteable {
 	private double a, b, c, d, e, f;
 
 	public double getA() {

--- a/src/main/java/net/alenzen/a2l/CoeffsLinear.java
+++ b/src/main/java/net/alenzen/a2l/CoeffsLinear.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class CoeffsLinear implements IA2LWriteable {
+public class CoeffsLinear extends A2LSerializer implements IA2LWriteable {
 	private double a;
 	private double b;
 

--- a/src/main/java/net/alenzen/a2l/CompuMethod.java
+++ b/src/main/java/net/alenzen/a2l/CompuMethod.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 
 import net.alenzen.a2l.enums.ConversionType;
 
-public class CompuMethod implements IA2LWriteable {
+public class CompuMethod extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private String longIdentifier;
 	private ConversionType conversionType;

--- a/src/main/java/net/alenzen/a2l/CompuTab.java
+++ b/src/main/java/net/alenzen/a2l/CompuTab.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 import net.alenzen.a2l.enums.ConversionType;
 
-public class CompuTab implements IA2LWriteable {
+public class CompuTab extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private String longIdentifier;
 	private ConversionType conversionType;

--- a/src/main/java/net/alenzen/a2l/CompuVTab.java
+++ b/src/main/java/net/alenzen/a2l/CompuVTab.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 import net.alenzen.a2l.enums.ConversionType;
 
-public class CompuVTab implements IA2LWriteable {
+public class CompuVTab extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private String longIdentifier;
 	private ConversionType conversionType;

--- a/src/main/java/net/alenzen/a2l/CompuVTabRange.java
+++ b/src/main/java/net/alenzen/a2l/CompuVTabRange.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class CompuVTabRange implements IA2LWriteable {
+public class CompuVTabRange extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private String longIdentifier;
 	private long numberOfValueTriples;

--- a/src/main/java/net/alenzen/a2l/CriterionTuple.java
+++ b/src/main/java/net/alenzen/a2l/CriterionTuple.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-class CriterionTuple implements IA2LWriteable {
+class CriterionTuple extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private String value;
 

--- a/src/main/java/net/alenzen/a2l/DependentCharacteristic.java
+++ b/src/main/java/net/alenzen/a2l/DependentCharacteristic.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class DependentCharacteristic implements IA2LWriteable {
+public class DependentCharacteristic extends A2LSerializer implements IA2LWriteable {
 	private String formula;
 	private List<String> characterstics;
 

--- a/src/main/java/net/alenzen/a2l/DistOpXYZ45.java
+++ b/src/main/java/net/alenzen/a2l/DistOpXYZ45.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import net.alenzen.a2l.enums.DataType;
 
-public class DistOpXYZ45 implements IA2LDimensionWriteable {
+public class DistOpXYZ45 extends A2LSerializer implements IA2LDimensionWriteable {
 	private long position;
 	private DataType dataType;
 

--- a/src/main/java/net/alenzen/a2l/ExtendedLimits.java
+++ b/src/main/java/net/alenzen/a2l/ExtendedLimits.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class ExtendedLimits implements IA2LWriteable {
+public class ExtendedLimits extends A2LSerializer implements IA2LWriteable {
 	private double lowerLimit;
 	private double upperLimit;
 

--- a/src/main/java/net/alenzen/a2l/FixAxisPar.java
+++ b/src/main/java/net/alenzen/a2l/FixAxisPar.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class FixAxisPar implements IA2LWriteable {
+public class FixAxisPar extends A2LSerializer implements IA2LWriteable {
 	private long offset;
 	private long shift;
 	private long numberapo;

--- a/src/main/java/net/alenzen/a2l/FixAxisParList.java
+++ b/src/main/java/net/alenzen/a2l/FixAxisParList.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Arrays;
 
 
-public class FixAxisParList implements IA2LWriteable {
+public class FixAxisParList extends A2LSerializer implements IA2LWriteable {
 	private double[] axisPtsValues;
 
 	public double[] getAxisPtsValues() {

--- a/src/main/java/net/alenzen/a2l/FixNoAxisPtsXYZ45.java
+++ b/src/main/java/net/alenzen/a2l/FixNoAxisPtsXYZ45.java
@@ -3,7 +3,7 @@ package net.alenzen.a2l;
 import java.util.Objects;
 
 
-public class FixNoAxisPtsXYZ45 implements IA2LDimensionWriteable {
+public class FixNoAxisPtsXYZ45 extends A2LSerializer implements IA2LDimensionWriteable {
 	private long numberOfAxisPoints;
 
 	public long getNumberOfAxisPoints() {

--- a/src/main/java/net/alenzen/a2l/FncValues.java
+++ b/src/main/java/net/alenzen/a2l/FncValues.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import net.alenzen.a2l.enums.AddrType;
 import net.alenzen.a2l.enums.DataType;
 
-public class FncValues implements IA2LWriteable {
+public class FncValues extends A2LSerializer implements IA2LWriteable {
 	private long position;
 	private DataType dataType;
 	private IndexMode indexMode;

--- a/src/main/java/net/alenzen/a2l/Formula.java
+++ b/src/main/java/net/alenzen/a2l/Formula.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class Formula implements IA2LWriteable {
+public class Formula extends A2LSerializer implements IA2LWriteable {
 	private String fx;
 
 	// optional parameters

--- a/src/main/java/net/alenzen/a2l/Frame.java
+++ b/src/main/java/net/alenzen/a2l/Frame.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class Frame implements IA2LWriteable {
+public class Frame extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private String longIdentifier;
 	private long scalingUnit;

--- a/src/main/java/net/alenzen/a2l/Function.java
+++ b/src/main/java/net/alenzen/a2l/Function.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class Function implements IA2LWriteable {
+public class Function extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private String longIdentifier;
 

--- a/src/main/java/net/alenzen/a2l/Group.java
+++ b/src/main/java/net/alenzen/a2l/Group.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class Group implements IA2LWriteable {
+public class Group extends A2LSerializer implements IA2LWriteable {
 	private String groupName;
 	private String longIdentifier;
 

--- a/src/main/java/net/alenzen/a2l/Header.java
+++ b/src/main/java/net/alenzen/a2l/Header.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class Header implements IA2LWriteable {
+public class Header extends A2LSerializer implements IA2LWriteable {
 	private String comment;
 
 	// optional parameters

--- a/src/main/java/net/alenzen/a2l/Identification.java
+++ b/src/main/java/net/alenzen/a2l/Identification.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 
 import net.alenzen.a2l.enums.DataType;
 
-public class Identification implements IA2LWriteable {
+public class Identification extends A2LSerializer implements IA2LWriteable {
 	private long position;
 	private DataType dataType;
 

--- a/src/main/java/net/alenzen/a2l/IfData.java
+++ b/src/main/java/net/alenzen/a2l/IfData.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class IfData implements IA2LWriteable {
+public class IfData extends A2LSerializer implements IA2LWriteable {
 	private String content;
 
 	public String getContent() {

--- a/src/main/java/net/alenzen/a2l/MatrixDim.java
+++ b/src/main/java/net/alenzen/a2l/MatrixDim.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class MatrixDim implements IA2LWriteable {
+public class MatrixDim extends A2LSerializer implements IA2LWriteable {
 	private long xDim;
 	private long yDim;
 	private long zDim;

--- a/src/main/java/net/alenzen/a2l/MaxRefresh.java
+++ b/src/main/java/net/alenzen/a2l/MaxRefresh.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class MaxRefresh implements IA2LWriteable {
+public class MaxRefresh extends A2LSerializer implements IA2LWriteable {
 	private long scalingUnit;
 	private long rate;
 

--- a/src/main/java/net/alenzen/a2l/Measurement.java
+++ b/src/main/java/net/alenzen/a2l/Measurement.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 import net.alenzen.a2l.enums.ByteOrder;
 import net.alenzen.a2l.enums.DataType;
 
-public class Measurement implements IA2LWriteable {
+public class Measurement extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private String longIdentifier;
 	private DataType datatype;

--- a/src/main/java/net/alenzen/a2l/MemoryLayout.java
+++ b/src/main/java/net/alenzen/a2l/MemoryLayout.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class MemoryLayout implements IA2LWriteable {
+public class MemoryLayout extends A2LSerializer implements IA2LWriteable {
 	private PrgType prgType;
 	private long address;
 	private long size;

--- a/src/main/java/net/alenzen/a2l/MemorySegment.java
+++ b/src/main/java/net/alenzen/a2l/MemorySegment.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class MemorySegment implements IA2LWriteable {
+public class MemorySegment extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private String longIdentifier;
 	private PrgType prgType;

--- a/src/main/java/net/alenzen/a2l/ModCommon.java
+++ b/src/main/java/net/alenzen/a2l/ModCommon.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import net.alenzen.a2l.enums.ByteOrder;
 import net.alenzen.a2l.enums.Deposit;
 
-public class ModCommon implements IA2LWriteable {
+public class ModCommon extends A2LSerializer implements IA2LWriteable {
 	private String comment;
 
 	// optional parameters

--- a/src/main/java/net/alenzen/a2l/ModPar.java
+++ b/src/main/java/net/alenzen/a2l/ModPar.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class ModPar implements IA2LWriteable {
+public class ModPar extends A2LSerializer implements IA2LWriteable {
 	private String comment;
 
 	// optional parameters

--- a/src/main/java/net/alenzen/a2l/ModuleSubBlocks.java
+++ b/src/main/java/net/alenzen/a2l/ModuleSubBlocks.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class ModuleSubBlocks implements IA2LWriteable {
+public class ModuleSubBlocks extends A2LSerializer implements IA2LWriteable {
 	// optional parameters
 	private List<A2ml> a2ml;
 	private List<AxisPts> axisPts;

--- a/src/main/java/net/alenzen/a2l/NoAxisPtsXYZ45.java
+++ b/src/main/java/net/alenzen/a2l/NoAxisPtsXYZ45.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import net.alenzen.a2l.enums.DataType;
 
-public class NoAxisPtsXYZ45 implements IA2LDimensionWriteable {
+public class NoAxisPtsXYZ45 extends A2LSerializer implements IA2LDimensionWriteable {
 	private long position;
 	private DataType dataType;
 

--- a/src/main/java/net/alenzen/a2l/NoRescaleXYZ45.java
+++ b/src/main/java/net/alenzen/a2l/NoRescaleXYZ45.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import net.alenzen.a2l.enums.DataType;
 
-public class NoRescaleXYZ45 implements IA2LDimensionWriteable {
+public class NoRescaleXYZ45 extends A2LSerializer implements IA2LDimensionWriteable {
 	private long position;
 	private DataType dataType;
 

--- a/src/main/java/net/alenzen/a2l/OffsetXYZ45.java
+++ b/src/main/java/net/alenzen/a2l/OffsetXYZ45.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import net.alenzen.a2l.enums.DataType;
 
-public class OffsetXYZ45 implements IA2LDimensionWriteable {
+public class OffsetXYZ45 extends A2LSerializer implements IA2LDimensionWriteable {
 	private long position;
 	private DataType dataType;
 

--- a/src/main/java/net/alenzen/a2l/ProjectSubBlocks.java
+++ b/src/main/java/net/alenzen/a2l/ProjectSubBlocks.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class ProjectSubBlocks implements IA2LWriteable {
+public class ProjectSubBlocks extends A2LSerializer implements IA2LWriteable {
 	// optional parameters
 	private List<Module> modules;
 	

--- a/src/main/java/net/alenzen/a2l/RecordLayout.java
+++ b/src/main/java/net/alenzen/a2l/RecordLayout.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class RecordLayout implements IA2LWriteable {
+public class RecordLayout extends A2LSerializer implements IA2LWriteable {
 	private String name;
 
 	// optional parameters

--- a/src/main/java/net/alenzen/a2l/Reserved.java
+++ b/src/main/java/net/alenzen/a2l/Reserved.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 
 import net.alenzen.a2l.enums.DataSize;
 
-public class Reserved implements IA2LWriteable {
+public class Reserved extends A2LSerializer implements IA2LWriteable {
 	private long position;
 	private DataSize dataSize;
 

--- a/src/main/java/net/alenzen/a2l/RipAddrWXYZ45.java
+++ b/src/main/java/net/alenzen/a2l/RipAddrWXYZ45.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import net.alenzen.a2l.enums.DataType;
 
-public class RipAddrWXYZ45 implements IA2LDimensionWriteable {
+public class RipAddrWXYZ45 extends A2LSerializer implements IA2LDimensionWriteable {
 	private long position;
 	private DataType dataType;
 

--- a/src/main/java/net/alenzen/a2l/ShiftOpXYZ45.java
+++ b/src/main/java/net/alenzen/a2l/ShiftOpXYZ45.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import net.alenzen.a2l.enums.DataType;
 
-public class ShiftOpXYZ45 implements IA2LDimensionWriteable {
+public class ShiftOpXYZ45 extends A2LSerializer implements IA2LDimensionWriteable {
 	private long position;
 	private DataType dataType;
 

--- a/src/main/java/net/alenzen/a2l/SiExponents.java
+++ b/src/main/java/net/alenzen/a2l/SiExponents.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class SiExponents implements IA2LWriteable {
+public class SiExponents extends A2LSerializer implements IA2LWriteable {
 	private long length;
 	private long mass;
 	private long time;

--- a/src/main/java/net/alenzen/a2l/SrcAddrXYZ45.java
+++ b/src/main/java/net/alenzen/a2l/SrcAddrXYZ45.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import net.alenzen.a2l.enums.DataType;
 
-public class SrcAddrXYZ45 implements IA2LDimensionWriteable {
+public class SrcAddrXYZ45 extends A2LSerializer implements IA2LDimensionWriteable {
 	private long position;
 	private DataType dataType;
 

--- a/src/main/java/net/alenzen/a2l/SymbolLink.java
+++ b/src/main/java/net/alenzen/a2l/SymbolLink.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class SymbolLink implements IA2LWriteable {
+public class SymbolLink extends A2LSerializer implements IA2LWriteable {
 	private String symbolName;
 	private long offset;
 

--- a/src/main/java/net/alenzen/a2l/SystemConstant.java
+++ b/src/main/java/net/alenzen/a2l/SystemConstant.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class SystemConstant implements IA2LWriteable {
+public class SystemConstant extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private String value;
 

--- a/src/main/java/net/alenzen/a2l/Unit.java
+++ b/src/main/java/net/alenzen/a2l/Unit.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class Unit implements IA2LWriteable {
+public class Unit extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private String longIdentifier;
 	private String display;

--- a/src/main/java/net/alenzen/a2l/UnitConversion.java
+++ b/src/main/java/net/alenzen/a2l/UnitConversion.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class UnitConversion implements IA2LWriteable {
+public class UnitConversion extends A2LSerializer implements IA2LWriteable {
 	private double gradient;
 	private double offset;
 

--- a/src/main/java/net/alenzen/a2l/UserRights.java
+++ b/src/main/java/net/alenzen/a2l/UserRights.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class UserRights implements IA2LWriteable {
+public class UserRights extends A2LSerializer implements IA2LWriteable {
 	private String userLevelId;
 
 	// optional parameters

--- a/src/main/java/net/alenzen/a2l/ValuePair.java
+++ b/src/main/java/net/alenzen/a2l/ValuePair.java
@@ -3,7 +3,7 @@ package net.alenzen.a2l;
 import java.util.Objects;
 
 
-public class ValuePair<T, U> {
+public class ValuePair<T, U> extends A2LSerializer {
 	private T inVal;
 	private U outVal;
 

--- a/src/main/java/net/alenzen/a2l/ValueTriple.java
+++ b/src/main/java/net/alenzen/a2l/ValueTriple.java
@@ -3,7 +3,7 @@ package net.alenzen.a2l;
 import java.util.Objects;
 
 
-public class ValueTriple<T1, T2> {
+public class ValueTriple<T1, T2> extends A2LSerializer {
 	private T1 inValMin;
 	private T1 inValMax;
 	private T2 outVal;

--- a/src/main/java/net/alenzen/a2l/VarCharacteristic.java
+++ b/src/main/java/net/alenzen/a2l/VarCharacteristic.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class VarCharacteristic implements IA2LWriteable {
+public class VarCharacteristic extends A2LSerializer implements IA2LWriteable {
 	private String name;
 
 	// optional parameters

--- a/src/main/java/net/alenzen/a2l/VarCriterion.java
+++ b/src/main/java/net/alenzen/a2l/VarCriterion.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class VarCriterion implements IA2LWriteable {
+public class VarCriterion extends A2LSerializer implements IA2LWriteable {
 	private String name;
 	private String longIdentifier;
 

--- a/src/main/java/net/alenzen/a2l/VarForbiddenComb.java
+++ b/src/main/java/net/alenzen/a2l/VarForbiddenComb.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class VarForbiddenComb implements IA2LWriteable {
+public class VarForbiddenComb extends A2LSerializer implements IA2LWriteable {
 	private List<CriterionTuple> tuples;
 
 	public List<CriterionTuple> getTuples() {

--- a/src/main/java/net/alenzen/a2l/VariantCoding.java
+++ b/src/main/java/net/alenzen/a2l/VariantCoding.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class VariantCoding implements IA2LWriteable {
+public class VariantCoding extends A2LSerializer implements IA2LWriteable {
 	private List<VarCharacteristic> varCharacteristics;
 	private List<VarCriterion> varCriterion;
 	private List<VarForbiddenComb> varForbiddenComb;

--- a/src/main/java/net/alenzen/a2l/Version.java
+++ b/src/main/java/net/alenzen/a2l/Version.java
@@ -3,7 +3,7 @@ package net.alenzen.a2l;
 import java.util.Objects;
 
 
-public abstract class Version implements IA2LWriteable {
+public abstract class Version extends A2LSerializer implements IA2LWriteable {
 	private long versionNo;
 	private long upgradeNo;
 

--- a/src/main/java/net/alenzen/a2l/VirtualCharacteristic.java
+++ b/src/main/java/net/alenzen/a2l/VirtualCharacteristic.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 
-public class VirtualCharacteristic implements IA2LWriteable {
+public class VirtualCharacteristic extends A2LSerializer implements IA2LWriteable {
 	private String formula;
 	private IdentReferenceList characterstics;
 


### PR DESCRIPTION
Fixes #10 

Hi Andreas,
I implemented the serializer using ObjectMapper as you suggested.

The best solution I could find to avoid duplicated code was to extend an abstract class. If you have another suggestion, just let me know and I can do it. =)

Thanks.