### PR TITLE
Corrected a bug realated to building the paths of included a2l files

### DIFF
--- a/src/main/java/net/alenzen/a2l/Asap2Parser.java
+++ b/src/main/java/net/alenzen/a2l/Asap2Parser.java
@@ -86,12 +86,19 @@ public class Asap2Parser {
 
 	public IIncludedFileMapper getStandardFileMapper(String rootFile) {
 		return (filepath) -> {
-			String finaPathToIncludeFile = rootFile;
+			String finalPathToIncludeFile = rootFile;
 			if (filepath != null) {
-				String filePathDir = new File(filepath).getParent();
-				finaPathToIncludeFile = Paths.get(filePathDir, rootFile).toString();
+				// If filepath is not an absolute path, combine it with rootFile's directory
+				File file = new File(filepath);
+				if (!file.isAbsolute()) {
+					String rootFileDir = new File(rootFile).getParent();
+					finalPathToIncludeFile = Paths.get(rootFileDir, filepath).toString();
+				} else {
+					// If filepath is absolute, just use filepath
+					finalPathToIncludeFile = filepath;
+				}
 			}
-			return new FileInputStream(finaPathToIncludeFile);
+			return new FileInputStream(finalPathToIncludeFile);
 		};
 	}
 


### PR DESCRIPTION
I found a bug, if there are includes like "/include "DataBase/ReferredA2lFile.a2l "  in the main a2l to be parsed, the construction of the standard file mapper fails to construct the correct path to the containing folder, that means it returns an error like this: 
java.nio.file.InvalidPathException: Illegal char <:> at index 10: DataBase\C:\...
at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:204)        at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:175)        at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)        at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)        at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:231)        at java.base/java.nio.file.Path.of(Path.java:148)        at java.base/java.nio.file.Paths.get(Paths.java:69)        at net.alenzen.a2l.Asap2Parser.lambda$getStandardFileMapper$2(Asap2Parser.java:90)        at ...

To work this around, I added a check, if the filepath is not absolute, it constructs the path using the path of the rootFile. 